### PR TITLE
Implements Phase 2 of the refactoring plan: Adaptive Particle Sorting.

### DIFF
--- a/base/mqi_track.hpp
+++ b/base/mqi_track.hpp
@@ -228,5 +228,15 @@ assert_track(const mqi::track_t<R>& trk, int8_t id = -1) {
     }
 }
 
+///< Functor to sort tracks by kinetic energy in descending order
+template<typename R>
+struct by_energy {
+    CUDA_HOST_DEVICE
+    bool
+    operator()(const track_t<R>& a, const track_t<R>& b) {
+        return a.vtx1.ke > b.vtx1.ke;
+    }
+};
+
 }   // namespace mqi
 #endif


### PR DESCRIPTION
This change introduces a sorting step before the main particle transport simulation. The particles (tracks) are now sorted by kinetic energy in descending order on the GPU using the Thrust library. This is intended to improve cache coherency and reduce thread divergence, leading to better performance.

Changes include:
- A new CUDA kernel `create_tracks_from_vertices` to convert vertex data into track objects on the GPU.
- The `run_simulation` function in `mqi_tps_env.hpp` is updated to orchestrate the creation and sorting of tracks before calling the transport kernel.
- The `transport_particles_patient` kernel is modified to work with `track_t` objects instead of `vertex_t`.
- A new sorting functor `by_energy` is added to `mqi_track.hpp`.