### PR TITLE
Fix CUDA compilation error in `mqi_interaction.hpp`

### DIFF
--- a/base/mqi_fippel_physics.hpp
+++ b/base/mqi_fippel_physics.hpp
@@ -54,7 +54,7 @@ public:
     }
 
     ///< step length
-    CUDA_DEVICE
+    CUDA_HOST_DEVICE
     virtual void
     stepping(track_t<R>&       trk,
              track_stack_t<R>& stk,

--- a/base/mqi_interaction.hpp
+++ b/base/mqi_interaction.hpp
@@ -66,7 +66,7 @@ public:
 
     ///< Return cross-section of the process in mm unit
     ///< pure virtual method so that a child needs to fill
-    CUDA_DEVICE
+    CUDA_HOST_DEVICE
     virtual R
     cross_section(const relativistic_quantities<R>& rel, const material_t<R>& mat) = 0;
 

--- a/base/mqi_p_ionization.hpp
+++ b/base/mqi_p_ionization.hpp
@@ -31,7 +31,7 @@ public:
     }
 
     ///< Cross-section
-    CUDA_DEVICE
+    CUDA_HOST_DEVICE
     virtual R
     cross_section(const relativistic_quantities<R>& rel, const material_t<R>& mat) {
         R cs = 0;

--- a/base/mqi_po_elastic.hpp
+++ b/base/mqi_po_elastic.hpp
@@ -77,7 +77,7 @@ class po_elastic : public interaction<R, mqi::PROTON>
 {
 public:
 public:
-    CUDA_DEVICE
+    CUDA_HOST_DEVICE
     virtual R
     cross_section(const relativistic_quantities<R>& rel, const material_t<R>& mat) {
         R cs = 0;
@@ -246,7 +246,7 @@ public:
     ~po_elastic_tabulated() {
     }
 
-    CUDA_DEVICE
+    CUDA_HOST_DEVICE
     virtual R
     cross_section(const relativistic_quantities<R>& rel, const material_t<R>& mat) {
         R cs = 0;

--- a/base/mqi_po_inelastic.hpp
+++ b/base/mqi_po_inelastic.hpp
@@ -90,7 +90,7 @@ public:
         ;
     }
 
-    CUDA_DEVICE
+    CUDA_HOST_DEVICE
     virtual R
     cross_section(const relativistic_quantities<R>& rel, const material_t<R>& mat) {
         R cs = 0;
@@ -150,7 +150,7 @@ public:
     ~po_inelastic_tabulated() {
     }
 
-    CUDA_DEVICE
+    CUDA_HOST_DEVICE
     virtual R
     cross_section(const relativistic_quantities<R>& rel, const material_t<R>& mat) {
         R cs = 0;

--- a/base/mqi_pp_elastic.hpp
+++ b/base/mqi_pp_elastic.hpp
@@ -76,7 +76,7 @@ class pp_elastic : public interaction<R, mqi::PROTON>
 {
 
 public:
-    CUDA_DEVICE
+    CUDA_HOST_DEVICE
     virtual R
     cross_section(const relativistic_quantities<R>& rel, const material_t<R>& mat) {
         R cs = 0;
@@ -229,7 +229,7 @@ public:
         stk.push_secondary(daughter);
     }
 
-    CUDA_DEVICE
+    CUDA_HOST_DEVICE
     virtual R
     cross_section(const relativistic_quantities<R>& rel, const material_t<R>& mat) {
         R cs = 0;


### PR DESCRIPTION
The `sample_step_length` function, marked as `__host__ __device__`, was calling the `cross_section` function, which was marked as `__device__` only. This is not allowed when compiling for the host.

This commit fixes the issue by marking `cross_section` and all its implementations as `__host__ __device__`. It also marks the `stepping` function in `fippel_physics` as `__host__ __device__` as it calls `cross_section`.