### PR TITLE
Fix CUDA compilation error in cross_section functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(GPU ON)
 
 # setting Cuda 11.7 
 set(CMAKE_CUDA_COMPILER /usr/local/cuda-11.7/bin/nvcc CACHE FILEPATH "CUDA 11.7 nvcc" FORCE)
-set(CUDATOOLkit_ROOT /usr/local/cuda-11.7 CACHE PATH "CUDA 11.7 root" FORCE)
+set(CUDAToolkit_ROOT /usr/local/cuda-11.7 CACHE PATH "CUDA 11.7 root" FORCE)
 set(MOQUI_DIR ../moqui)
 add_executable(tps_env tps_env.cpp)
 

--- a/base/mqi_po_elastic.hpp
+++ b/base/mqi_po_elastic.hpp
@@ -250,11 +250,15 @@ public:
     virtual R
     cross_section(const relativistic_quantities<R>& rel, const material_t<R>& mat) {
         R cs = 0;
+#ifdef __CUDA_ARCH__
         if (rel.Ek >= Ek_min && rel.Ek <= Ek_max) {
             float u = (rel.Ek - Ek_min) / dEk + 0.5f;
-            cs = tex2D<float>(tex_, u, 3.5f);
+            cs      = tex2D<float>(tex_, u, 3.5f);
         }
         cs *= mat.rho_mass;
+#else
+        cs = po_elastic<R>::cross_section(rel, mat);
+#endif
         return cs;
     }
 };

--- a/base/mqi_po_inelastic.hpp
+++ b/base/mqi_po_inelastic.hpp
@@ -155,11 +155,15 @@ public:
     cross_section(const relativistic_quantities<R>& rel, const material_t<R>& mat) {
         R cs = 0;
 
+#ifdef __CUDA_ARCH__
         if (rel.Ek >= Ek_min && rel.Ek <= Ek_max) {
             float u = (rel.Ek - Ek_min) / dEk + 0.5f;
-            cs = tex2D<float>(tex_, u, 4.5f);
+            cs      = tex2D<float>(tex_, u, 4.5f);
         }
         cs *= mat.rho_mass;
+#else
+        cs = po_inelastic<R>::cross_section(rel, mat);
+#endif
         return cs;
     }
 

--- a/base/mqi_pp_elastic.hpp
+++ b/base/mqi_pp_elastic.hpp
@@ -234,11 +234,15 @@ public:
     cross_section(const relativistic_quantities<R>& rel, const material_t<R>& mat) {
         R cs = 0;
 
+#ifdef __CUDA_ARCH__
         if (rel.Ek >= Ek_min && rel.Ek <= Ek_max) {
             float u = (rel.Ek - Ek_min) / dEk + 0.5f;
-            cs = tex2D<float>(tex_, u, 5.5f);
+            cs      = tex2D<float>(tex_, u, 5.5f);
         }
         cs *= mat.rho_mass;
+#else
+        cs = pp_elastic<R>::cross_section(rel, mat);
+#endif
         return cs;
     }
 };


### PR DESCRIPTION
The `cross_section` functions in `po_elastic_tabulated`, `po_inelastic_tabulated`, and `pp_elastic_tabulated` were marked as `__host__ __device__` but were calling the `tex2D` function, which is a `__device__`-only function. This caused a compilation error when the functions were compiled for the host.

This commit fixes the issue by wrapping the `tex2D` call and related device-only code in an `#ifdef __CUDA_ARCH__` block. This ensures that the device-specific code is only compiled for the GPU. For the host compilation path, the functions now call the base class's `cross_section` implementation as a fallback.

Additionally, this commit fixes a typo in `CMakeLists.txt` where `CUDATOOLkit_ROOT` was misspelled as `CUDATOOLkit_ROOT`, which was preventing CMake from finding the CUDA toolkit.